### PR TITLE
UNet refactor

### DIFF
--- a/ivy_models/unet/unet.py
+++ b/ivy_models/unet/unet.py
@@ -1,7 +1,8 @@
-from .layers import UNetDoubleConv, UNetDown, UNetOutConv, UNetUp
-from ivy_models.helpers import load_torch_weights
 import ivy
+from .layers import UNetDoubleConv, UNetDown, UNetOutConv, UNetUp
+
 import builtins
+from ivy_models.helpers import load_torch_weights
 
 
 class UNET(ivy.Module):
@@ -9,20 +10,20 @@ class UNET(ivy.Module):
         self.n_channels = n_channels
         self.n_classes = n_classes
         self.bilinear = bilinear
+        self.factor = 2 if bilinear else 1
+        super(UNET, self).__init__(v=v)
 
-        self.inc = UNetDoubleConv(n_channels, 64)
+    def _build(self, *args, **kwargs):
+        self.inc = UNetDoubleConv(self.n_channels, 64)
         self.down1 = UNetDown(64, 128)
         self.down2 = UNetDown(128, 256)
         self.down3 = UNetDown(256, 512)
-        factor = 2 if bilinear else 1
-        self.down4 = UNetDown(512, 1024 // factor)
-        self.up1 = UNetUp(1024, 512 // factor, bilinear)
-        self.up2 = UNetUp(512, 256 // factor, bilinear)
-        self.up3 = UNetUp(256, 128 // factor, bilinear)
-        self.up4 = UNetUp(128, 64, bilinear)
-        self.outc = UNetOutConv(64, n_classes)
-
-        super(UNET, self).__init__(v=v)
+        self.down4 = UNetDown(512, 1024 // self.factor)
+        self.up1 = UNetUp(1024, 512 // self.factor, self.bilinear)
+        self.up2 = UNetUp(512, 256 // self.factor, self.bilinear)
+        self.up3 = UNetUp(256, 128 // self.factor, self.bilinear)
+        self.up4 = UNetUp(128, 64, self.bilinear)
+        self.outc = UNetOutConv(64, self.n_classes)
 
     def _forward(self, x):
         x1 = self.inc(x)
@@ -60,7 +61,7 @@ def unet_carvana(n_channels=3, n_classes=2, v=None, pretrained=True):
     if not pretrained:
         return UNET(n_channels=n_channels, n_classes=n_classes, v=v)
 
-    reference_model = UNET(n_channels=n_channels, n_classes=n_classes)
+    reference_model = UNET(n_channels=3, n_classes=2)
     url = "https://github.com/milesial/Pytorch-UNet/releases/download/v3.0/unet_carvana_scale1.0_epoch2.pth"  # noqa
     w_clean = load_torch_weights(
         url,
@@ -68,4 +69,4 @@ def unet_carvana(n_channels=3, n_classes=2, v=None, pretrained=True):
         raw_keys_to_prune=["num_batches_tracked"],
         custom_mapping=_unet_torch_weights_mapping,
     )
-    return UNET(n_channels=n_channels, n_classes=n_classes, v=w_clean)
+    return UNET(n_channels=3, n_classes=2, v=w_clean)

--- a/ivy_models_tests/unet/test_unet.py
+++ b/ivy_models_tests/unet/test_unet.py
@@ -1,33 +1,35 @@
-# import os
-# import ivy
-# import pytest
-# import numpy as np
-# import jax
+import os
+import ivy
+import pytest
+import numpy as np
+import jax
 
-# # Enable x64 support in JAX
-# jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_enable_x64", False)
 
-# from ivy_models.unet import UNet
-# from ivy_models_tests import helpers
+from ivy_models.unet import unet_carvana
+from ivy_models_tests import helpers
 
 
-# @pytest.mark.parametrize("batch_shape", [[1]])
-# @pytest.mark.parametrize("load_weights", [False, True])
-# def test_unet_img_segmentation(device, f, fw, batch_shape, load_weights):
-#     """Test ResNet-18 image classification."""
-#     num_classes = 1000
-#     this_dir = os.path.dirname(os.path.realpath(__file__))
+@pytest.mark.parametrize("batch_shape", [[1]])
+@pytest.mark.parametrize("load_weights", [False, True])
+def test_unet_img_segmentation(device, f, fw, batch_shape, load_weights):
+    """Test UNet image segmentation"""
+    this_dir = os.path.dirname(os.path.realpath(__file__))
 
-#     # Load image
-#     img = helpers.load_and_preprocess_img(
-#         os.path.join(this_dir, "..", "..", "images", "cat.jpg"), 256, 224
-#     )
+    # Load image
+    img = helpers.load_and_preprocess_img(
+        os.path.join(this_dir, "..", "..", "images", "car.jpg"), 256, 224
+    )
 
-#     # Create model
-#     model = UNet(pretrained=load_weights)
+    # Create model
+    model = unet_carvana(pretrained=load_weights)
 
-#     # Perform inference
-#     output = model(img)
+    # Perform inference
+    output = model(img)
+    output_np = ivy.to_numpy(output)
 
-#     # Cardinality test
-#     assert output.shape == tuple([ivy.to_scalar(batch_shape), num_classes])
+    # Cardinality test
+    assert output.shape == tuple([1, 224, 224, 2])
+
+    if load_weights:
+        assert np.allclose(output_np.sum(), np.array([111573.26]), rtol=1.0)


### PR DESCRIPTION
- Refactored to use _build 
- Fixed a bug that fixes TensorFlow and JAX backends, the issue was Conv2DTranspose takes a string or tuple of integers as padding, rather than a single integer.
- Added a very simple placeholder test that confirms that the model runs on the backends & checks the sum of the output.