### PR TITLE
fix: replaced double quote in line 63 in README.rst that where causing error when building the project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Getting started
 
     import ivy
     from ivy_models import alexnet
-    ivy.set_backend(“torch”)
+    ivy.set_backend("torch")
     model = alexnet()
 
 The pretrained AlexNet model is now ready to be used, and is compatible with any other PyTorch code.


### PR DESCRIPTION
there was a unicode error when trying to install the project with "pip install ." due to the existing double quotes